### PR TITLE
Add WHMCS trial billing addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # datest
-datest
+
+This repository includes a sample WHMCS addon module called **Trial Billing**.
+The addon provides a 7‑day free trial for non‑domain products.
+After the trial ends, the service is suspended and an invoice is created for the normal price.
+See `modules/addons/trialbilling/README.md` for details.

--- a/modules/addons/trialbilling/README.md
+++ b/modules/addons/trialbilling/README.md
@@ -1,0 +1,25 @@
+# Trial Billing WHMCS Addon
+
+This addon provides a 7-day free trial for all products except domain registrations.
+When a client orders a product, the initial invoice is zeroed and marked as paid.
+After 7 days, the service is suspended and a new invoice is generated for the original price.
+
+## Installation
+1. Copy the `trialbilling` folder to your WHMCS `modules/addons/` directory.
+2. From the WHMCS admin area, navigate to **Setup > Addon Modules** and activate *Trial Billing*.
+3. Configure the addon permissions if required.
+
+## How It Works
+- At order time, all non-domain items in the invoice are set to zero and marked paid.
+- The original price and service ID are stored in the `mod_trialbilling` table.
+- A daily cron checks for expired trials. After 7 days it creates an invoice for the original amount and suspends the service.
+
+## File Map
+```
+modules/
+└─ addons/
+   └─ trialbilling/
+      ├─ trialbilling.php     # Addon module definition
+      ├─ hooks.php            # Hooks implementing trial logic
+      └─ README.md           # This documentation
+```

--- a/modules/addons/trialbilling/hooks.php
+++ b/modules/addons/trialbilling/hooks.php
@@ -1,0 +1,66 @@
+<?php
+if (!defined('WHMCS')) {
+    exit('This file cannot be accessed directly');
+}
+
+use WHMCS\Database\Capsule;
+
+/**
+ * Zero price on initial invoice for non-domain products
+ * and store original price for billing after trial.
+ */
+add_hook('InvoiceCreationPreEmail', 1, function($vars) {
+    $invoiceId = $vars['invoiceid'];
+    $items = Capsule::table('tblinvoiceitems')->where('invoiceid', $invoiceId)->get();
+    $totalAdjustment = 0;
+    foreach ($items as $item) {
+        if ($item->type !== 'Domain' && $item->type !== 'AddFunds') {
+            Capsule::table('mod_trialbilling')->insert([
+                'serviceid' => $item->relid,
+                'originalamount' => $item->amount,
+                'expirydate' => date('Y-m-d', strtotime('+7 days')),
+            ]);
+            $totalAdjustment += $item->amount;
+            Capsule::table('tblinvoiceitems')->where('id', $item->id)->update(['amount' => 0]);
+        }
+    }
+    if ($totalAdjustment > 0) {
+        $invoice = Capsule::table('tblinvoices')->where('id', $invoiceId)->first();
+        $newTotal = $invoice->total - $totalAdjustment;
+        Capsule::table('tblinvoices')->where('id', $invoiceId)
+            ->update([
+                'total' => $newTotal,
+                'subtotal' => $invoice->subtotal - $totalAdjustment,
+                'status' => 'Paid',
+            ]);
+    }
+});
+
+/**
+ * Daily cron to invoice and suspend expired trial services
+ */
+add_hook('DailyCronJob', 1, function($vars) {
+    $today = date('Y-m-d');
+    $trials = Capsule::table('mod_trialbilling')->where('expirydate', '<=', $today)->get();
+    foreach ($trials as $trial) {
+        $service = Capsule::table('tblhosting')->where('id', $trial->serviceid)->first();
+        if (!$service) {
+            Capsule::table('mod_trialbilling')->where('id', $trial->id)->delete();
+            continue;
+        }
+        // Create invoice for original amount
+        localAPI('CreateInvoice', [
+            'userid' => $service->userid,
+            'date' => $today,
+            'duedate' => $today,
+            'itemdescription1' => 'Service ' . $service->id . ' trial ended',
+            'itemamount1' => $trial->originalamount,
+        ], 'admin');
+        // Suspend the service
+        localAPI('ModuleSuspend', [
+            'accountid' => $service->id,
+            'suspendreason' => 'Trial expired',
+        ], 'admin');
+        Capsule::table('mod_trialbilling')->where('id', $trial->id)->delete();
+    }
+});

--- a/modules/addons/trialbilling/trialbilling.php
+++ b/modules/addons/trialbilling/trialbilling.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('WHMCS')) {
+    exit('This file cannot be accessed directly');
+}
+
+use WHMCS\Database\Capsule;
+
+function trialbilling_config()
+{
+    return [
+        'name' => 'Trial Billing',
+        'description' => 'Allows 7-day free trial for non-domain products and bills at full price after expiration.',
+        'version' => '1.0',
+        'author' => 'Example',
+    ];
+}
+
+function trialbilling_activate()
+{
+    Capsule::schema()->create('mod_trialbilling', function ($table) {
+        $table->increments('id');
+        $table->integer('serviceid');
+        $table->decimal('originalamount', 10, 2);
+        $table->date('expirydate');
+    });
+    return ['status' => 'success'];
+}
+
+function trialbilling_deactivate()
+{
+    Capsule::schema()->dropIfExists('mod_trialbilling');
+    return ['status' => 'success'];
+}
+
+function trialbilling_output($vars)
+{
+    echo '<p>Trial Billing module is active.</p>';
+}


### PR DESCRIPTION
## Summary
- add Trial Billing addon module for WHMCS
- document addon and repository

## Testing
- `php -l modules/addons/trialbilling/trialbilling.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68484832e6dc832ca53dcd37c98862ff